### PR TITLE
Bugfix: display past shows

### DIFF
--- a/src/components/shows/shows.js
+++ b/src/components/shows/shows.js
@@ -60,8 +60,8 @@ const Shows = () => {
   return (
     <>
       <h1>Shows</h1>
-      {upcoming.length && showList(upcoming, 'Upcoming')}
-      {past.length && showList(upcoming, 'Past')}
+      {upcoming.length > 0 && showList(upcoming, 'Upcoming')}
+      {past.length > 0 && showList(past, 'Past')}
     </>
   )
 }


### PR DESCRIPTION
Date comparison is working after all, but `upcoming` show data was being used in both sections and because of that `past` shows were not rendered.